### PR TITLE
Improve playbook performance

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,6 @@
 [defaults]
 host_key_checking = False
-# (pathlist) Comma separated list of Ansible inventory sources
 inventory=./inventory
+
+[connection]
+pipelining = True


### PR DESCRIPTION
Enable connection `pipelining`

This reduces playbook execution time for the OTC provider by 30%