### PR TITLE
Use `zuul-identity` `main` branch

### DIFF
--- a/ci/playbooks/pre.yaml
+++ b/ci/playbooks/pre.yaml
@@ -18,7 +18,6 @@
         repo: "{{ id_repo }}"
         dest: "{{ repo_tmp }}"
         depth: 1
-        version: "zuul-identity"
     - name: "Install requirements"
       args:
         chdir: "{{ repo_tmp }}"


### PR DESCRIPTION
Replace specific `zuul-identity` branch for internal use with latest base branch commit