### PR TITLE
Increase `verbosity` of logging one-time config

### DIFF
--- a/ci/playbooks/pre.yaml
+++ b/ci/playbooks/pre.yaml
@@ -45,6 +45,7 @@
     - name: "Log one-time identity cloud config"
       debug:
         var: iam_cloud
+        verbosity: 3
     - name: "Return values to the zuul"
       vars:
         auth: "{{ iam_cloud['auth'] }}"


### PR DESCRIPTION
Currently zuul logs one-time configuration. This is minor security problem.